### PR TITLE
Add a front page for search

### DIFF
--- a/docusearch/templates/search/index.html
+++ b/docusearch/templates/search/index.html
@@ -19,7 +19,7 @@
 <div class="hero">
     <div class="container">
         <section class="hero--content">
-            <h1><em>FOIA Hub makes it easy to search and find documents released through FOIA</em></h1>
+            <h1><em>FOIA Hub makes it easy to search and find documents released through the FOIA process</em></h1>
 
             <h2> Agencies make FOIA responsive records and other proactively
             disclosed documents available online. </h2>

--- a/docusearch/templates/search/index.html
+++ b/docusearch/templates/search/index.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block body %}
+
+<div class="search">
+    <div class="container">
+        <section class="search--content">
+        <h2>Search Government Records</h2>
+
+            <form class="agency" method="get" action="/documents/search">
+                <div class="search--box scrollable-dropdown-menu">
+                        <input id="id_q" name="q" type="search" value="{{request.GET.q}}" />
+                        <button type="submit" name="search">Search</button>
+                </div>
+            </form>
+        </section>
+    </div>
+</div>
+
+<div class="hero">
+    <div class="container">
+        <section class="hero--content">
+            <h1><em>FOIA Hub makes it easy to search and find documents released through FOIA</em></h1>
+
+            <h2> Agencies make FOIA responsive records and other proactively
+            disclosed documents available online. </h2>
+
+            <h2> We make them searchable, and link related documents from other
+            agencies together &mdash; helping you better find the records you
+            are looking for. </h2>
+        </section>
+    </div>
+</div>
+
+{% endblock body%}

--- a/docusearch/templates/search/search.html
+++ b/docusearch/templates/search/search.html
@@ -4,7 +4,7 @@
 <div class="search">
     <div class="container">
         <section class="search--content">
-        <h2>Search for Government Records</h2>
+        <h2>Search Government Records</h2>
 
             <form class="agency" method="get" action=".">
                 <div class="search--box scrollable-dropdown-menu">
@@ -19,6 +19,7 @@
 <div class="container">
     <section class="searchresults">
     {% if query %}
+        <hr />
         <h2>Displaying {{page.paginator.count}} Results</h2>
 
         <div>

--- a/docusearch/urls.py
+++ b/docusearch/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import patterns, url
+from django.views.generic import TemplateView
 
 from haystack.forms import FacetedSearchForm
 from haystack.query import SearchQuerySet
@@ -12,6 +13,7 @@ sqs = SearchQuerySet().models(Document).highlight().facet('')
 
 urlpatterns = patterns(
     'haystack.views',
+    url(r'^$', TemplateView.as_view(template_name='search/index.html'), name="home"),
     url(
         r'^search/',
         search_view_factory(

--- a/foia_hub/urls.py
+++ b/foia_hub/urls.py
@@ -31,7 +31,6 @@ urlpatterns = patterns(
     url(r'^request/(?P<slug>[-\w]+)/$', request_form, name='form'),
     url(r'^robots\.txt$',
         TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
-
 )
 
 # APIs


### PR DESCRIPTION
This adds in a front-page to the whole search effort. This allows us to put some explanatory text under a document search box. 

Currently, I have placeholder text. This will surely change over time. 
