### PR TITLE
Truncate highlighted text

### DIFF
--- a/docusearch/templates/search/search.html
+++ b/docusearch/templates/search/search.html
@@ -45,11 +45,16 @@
 
                 <div class="agencies--description">
                 <p>
+                {% for text in result.highlighted.text %}
+                    {{text}}
+                {% endfor %}
+                </p>
+                <p>
                 {% for htext in result.highlighted %}
                     {% if loop.last %}
-                        ... {{htext|safe|lower}} 
+                        {{htext|truncate(256)|lower|safe}}
                     {% else %}
-                        ... {{htext|safe|lower}} ... <br />
+                        ... {{htext|truncate(256)|lower|safe}} ... <br />
                     {% endif %}
                 {% endfor %}
                 </p>


### PR DESCRIPTION
Searching for "court order" resulted in this search results page (which is a little less than optimal): 

![screen shot 2015-02-20 at 1 42 01 pm](https://cloud.githubusercontent.com/assets/636752/6307104/497e9dc6-b907-11e4-9b27-d7d16360a4c8.png)

This pull request truncates the highlighted text. It's not a perfect solution, and we should later find something better - but for now the search results page doesn't look completely silly. 
